### PR TITLE
Improve help text formatting

### DIFF
--- a/opt-env-conf-test/test/OptEnvConf/APISpec.hs
+++ b/opt-env-conf-test/test/OptEnvConf/APISpec.hs
@@ -260,7 +260,7 @@ threeCommandsParser =
               [ help "enable extra",
                 name "enable"
               ],
-        command "three" "third" (pure Three)
+        command "three-very-long-command-name" "third" (pure Three)
       ]
 
 data SubCommands

--- a/opt-env-conf-test/test_resources/docs/args/help.txt
+++ b/opt-env-conf-test/test_resources/docs/args/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33margs[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [33mARGUMENT[m
+[36mUsage: [m[33margs[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [33mARGUMENT[m
 
 args parser
 

--- a/opt-env-conf-test/test_resources/docs/args/help.txt
+++ b/opt-env-conf-test/test_resources/docs/args/help.txt
@@ -15,3 +15,6 @@ args parser
   argument: [33mARGUMENT[m
   
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/args/help.txt
+++ b/opt-env-conf-test/test_resources/docs/args/help.txt
@@ -15,6 +15,3 @@ args parser
   argument: [33mARGUMENT[m
   
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/args/man.txt
+++ b/opt-env-conf-test/test_resources/docs/args/man.txt
@@ -21,6 +21,9 @@ args (-h|--help)
   argument: ARGUMENT
   
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/args/man.txt
+++ b/opt-env-conf-test/test_resources/docs/args/man.txt
@@ -21,9 +21,6 @@ args (-h|--help)
   argument: ARGUMENT
   
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/args/man.txt
+++ b/opt-env-conf-test/test_resources/docs/args/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-args (-h|--help) | --version | ARGUMENT
+args (-h|--help) 
+ | --version 
+ | ARGUMENT
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/args/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/args/opt-short.txt
@@ -1,1 +1,3 @@
-[33margs[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [33mARGUMENT[m
+[33margs[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [33mARGUMENT[m

--- a/opt-env-conf-test/test_resources/docs/args/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/args/reference.txt
@@ -13,6 +13,9 @@
   argument: [33mARGUMENT[m
   
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/args/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/args/reference.txt
@@ -13,9 +13,6 @@
   argument: [33mARGUMENT[m
   
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/args/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/args/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33margs[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [33mARGUMENT[m
+[36mUsage: [m[33margs[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [33mARGUMENT[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/big-config/help.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33mbig-config[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m[36m)[m
+[36mUsage: [m[33mbig-config[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m[36m)[m
 
 example with a big configuration
 

--- a/opt-env-conf-test/test_resources/docs/big-config/help.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/help.txt
@@ -23,6 +23,3 @@ example with a big configuration
           [33m<number>[m # [32m64 bit signed integer[m
   
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/big-config/help.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/help.txt
@@ -23,3 +23,6 @@ example with a big configuration
           [33m<number>[m # [32m64 bit signed integer[m
   
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/big-config/man.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/man.txt
@@ -29,6 +29,9 @@ big-config (-h|--help)
           <number> # 64 bit signed integer
   
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help     Show this help text               
   --version     Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/big-config/man.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-big-config (-h|--help) | --version | (--config-file FILE_PATH)
+big-config (-h|--help) 
+ | --version 
+ | (--config-file FILE_PATH)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/big-config/man.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/man.txt
@@ -29,9 +29,6 @@ big-config (-h|--help)
           <number> # 64 bit signed integer
   
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help     Show this help text               
   --version     Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/big-config/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/opt-short.txt
@@ -1,1 +1,3 @@
-[33mbig-config[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m[36m)[m
+[33mbig-config[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/big-config/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/reference.txt
@@ -21,9 +21,6 @@
           [33m<number>[m # [32m64 bit signed integer[m
   
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m     [34mShow this help text[m               
   [37m--version[m     [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/big-config/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33mbig-config[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m[36m)[m
+[36mUsage: [m[33mbig-config[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/big-config/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/big-config/reference.txt
@@ -21,6 +21,9 @@
           [33m<number>[m # [32m64 bit signed integer[m
   
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m     [34mShow this help text[m               
   [37m--version[m     [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/empty/help.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/help.txt
@@ -1,4 +1,5 @@
-[36mUsage: [m[33mempty[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m
+[36mUsage: [m[33mempty[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m
 
 empty parser
 

--- a/opt-env-conf-test/test_resources/docs/empty/help.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/help.txt
@@ -11,3 +11,6 @@ empty parser
   switch: [37m--version[m
   
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/empty/help.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/help.txt
@@ -11,6 +11,3 @@ empty parser
   switch: [37m--version[m
   
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/empty/man.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/man.txt
@@ -17,9 +17,6 @@ empty (-h|--help)
   switch: --version
   
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/empty/man.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/man.txt
@@ -17,6 +17,9 @@ empty (-h|--help)
   switch: --version
   
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/empty/man.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/man.txt
@@ -7,7 +7,8 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-empty (-h|--help) | --version
+empty (-h|--help) 
+ | --version
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/empty/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/opt-short.txt
@@ -1,1 +1,2 @@
-[33mempty[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m
+[33mempty[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m

--- a/opt-env-conf-test/test_resources/docs/empty/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/reference.txt
@@ -1,4 +1,5 @@
-[36mUsage: [m[33mempty[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m
+[36mUsage: [m[33mempty[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/empty/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/reference.txt
@@ -9,6 +9,9 @@
   switch: [37m--version[m
   
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/empty/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/empty/reference.txt
@@ -9,9 +9,6 @@
   switch: [37m--version[m
   
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/enable-disable/help.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/help.txt
@@ -23,3 +23,6 @@ enableDisableSwitch example
       [33m<boolean>[m
 
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/enable-disable/help.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33menable-disable[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--(enable|disable)-example[m[36m)[m
+[36mUsage: [m[33menable-disable[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--(enable|disable)-example[m[36m)[m
 
 enableDisableSwitch example
 

--- a/opt-env-conf-test/test_resources/docs/enable-disable/help.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/help.txt
@@ -23,6 +23,3 @@ enableDisableSwitch example
       [33m<boolean>[m
 
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/enable-disable/man.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-enable-disable (-h|--help) | --version | (--config-file FILE_PATH --(enable|disable)-example)
+enable-disable (-h|--help) 
+ | --version 
+ | (--config-file FILE_PATH --(enable|disable)-example)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/enable-disable/man.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/man.txt
@@ -29,9 +29,6 @@ enable-disable (-h|--help)
       <boolean>
 
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help                  Show this help text                 
   --version                  Output version information: 0.0.0   

--- a/opt-env-conf-test/test_resources/docs/enable-disable/man.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/man.txt
@@ -29,6 +29,9 @@ enable-disable (-h|--help)
       <boolean>
 
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help                  Show this help text                 
   --version                  Output version information: 0.0.0   

--- a/opt-env-conf-test/test_resources/docs/enable-disable/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/opt-short.txt
@@ -1,1 +1,3 @@
-[33menable-disable[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--(enable|disable)-example[m[36m)[m
+[33menable-disable[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--(enable|disable)-example[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/enable-disable/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33menable-disable[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--(enable|disable)-example[m[36m)[m
+[36mUsage: [m[33menable-disable[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--(enable|disable)-example[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/enable-disable/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/reference.txt
@@ -21,9 +21,6 @@
       [33m<boolean>[m
 
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m                  [34mShow this help text[m                 
   [37m--version[m                  [34mOutput version information: 0.0.0[m   

--- a/opt-env-conf-test/test_resources/docs/enable-disable/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/enable-disable/reference.txt
@@ -21,6 +21,9 @@
       [33m<boolean>[m
 
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m                  [34mShow this help text[m                 
   [37m--version[m                  [34mOutput version information: 0.0.0[m   

--- a/opt-env-conf-test/test_resources/docs/greet/help.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33mgreet[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m-g[m[36m|[m[37m--greeting[m [33mGREETING[m [33mSUBJECT[m [37m-p[m[36m|[m[37m--polite[m[36m)[m
+[36mUsage: [m[33mgreet[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m-g[m[36m|[m[37m--greeting[m [33mGREETING[m [33mSUBJECT[m [37m-p[m[36m|[m[37m--polite[m[36m)[m
 
 hello world example
 

--- a/opt-env-conf-test/test_resources/docs/greet/help.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/help.txt
@@ -33,3 +33,6 @@ hello world example
       [33m<boolean>[m
   
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/greet/help.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/help.txt
@@ -33,6 +33,3 @@ hello world example
       [33m<boolean>[m
   
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/greet/man.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/man.txt
@@ -39,9 +39,6 @@ greet (-h|--help)
       <boolean>
   
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help     Show this help text                               
   --version     Output version information: 0.0.0                 

--- a/opt-env-conf-test/test_resources/docs/greet/man.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-greet (-h|--help) | --version | (--config-file FILE_PATH -g|--greeting GREETING SUBJECT -p|--polite)
+greet (-h|--help) 
+ | --version 
+ | (--config-file FILE_PATH -g|--greeting GREETING SUBJECT -p|--polite)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/greet/man.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/man.txt
@@ -39,6 +39,9 @@ greet (-h|--help)
       <boolean>
   
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help     Show this help text                               
   --version     Output version information: 0.0.0                 

--- a/opt-env-conf-test/test_resources/docs/greet/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/opt-short.txt
@@ -1,1 +1,3 @@
-[33mgreet[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m-g[m[36m|[m[37m--greeting[m [33mGREETING[m [33mSUBJECT[m [37m-p[m[36m|[m[37m--polite[m[36m)[m
+[33mgreet[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m-g[m[36m|[m[37m--greeting[m [33mGREETING[m [33mSUBJECT[m [37m-p[m[36m|[m[37m--polite[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/greet/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/reference.txt
@@ -31,9 +31,6 @@
       [33m<boolean>[m
   
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m     [34mShow this help text[m                               
   [37m--version[m     [34mOutput version information: 0.0.0[m                 

--- a/opt-env-conf-test/test_resources/docs/greet/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/reference.txt
@@ -31,6 +31,9 @@
       [33m<boolean>[m
   
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m     [34mShow this help text[m                               
   [37m--version[m     [34mOutput version information: 0.0.0[m                 

--- a/opt-env-conf-test/test_resources/docs/greet/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/greet/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33mgreet[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m-g[m[36m|[m[37m--greeting[m [33mGREETING[m [33mSUBJECT[m [37m-p[m[36m|[m[37m--polite[m[36m)[m
+[36mUsage: [m[33mgreet[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m-g[m[36m|[m[37m--greeting[m [33mGREETING[m [33mSUBJECT[m [37m-p[m[36m|[m[37m--polite[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/hidden/help.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/help.txt
@@ -1,4 +1,5 @@
-[36mUsage: [m[33mhidden[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m
+[36mUsage: [m[33mhidden[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m
 
 example with hidden settings
 

--- a/opt-env-conf-test/test_resources/docs/hidden/help.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/help.txt
@@ -11,6 +11,3 @@ example with hidden settings
   switch: [37m--version[m
   
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/hidden/help.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/help.txt
@@ -11,3 +11,6 @@ example with hidden settings
   switch: [37m--version[m
   
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/hidden/man.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/man.txt
@@ -7,7 +7,8 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-hidden (-h|--help) | --version
+hidden (-h|--help) 
+ | --version
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/hidden/man.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/man.txt
@@ -17,6 +17,9 @@ hidden (-h|--help)
   switch: --version
   
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/hidden/man.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/man.txt
@@ -17,9 +17,6 @@ hidden (-h|--help)
   switch: --version
   
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/hidden/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/opt-short.txt
@@ -1,1 +1,2 @@
-[33mhidden[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m
+[33mhidden[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m

--- a/opt-env-conf-test/test_resources/docs/hidden/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/reference.txt
@@ -1,4 +1,5 @@
-[36mUsage: [m[33mhidden[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m
+[36mUsage: [m[33mhidden[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/hidden/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/reference.txt
@@ -9,6 +9,9 @@
   switch: [37m--version[m
   
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/hidden/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/hidden/reference.txt
@@ -9,9 +9,6 @@
   switch: [37m--version[m
   
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/optional/help.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/help.txt
@@ -15,6 +15,3 @@ optional argument
   argument: [33mARGUMENT[m
   
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/optional/help.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/help.txt
@@ -15,3 +15,6 @@ optional argument
   argument: [33mARGUMENT[m
   
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/optional/help.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33moptional[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [33mARGUMENT[m
+[36mUsage: [m[33moptional[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [33mARGUMENT[m
 
 optional argument
 

--- a/opt-env-conf-test/test_resources/docs/optional/man.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/man.txt
@@ -21,6 +21,9 @@ optional (-h|--help)
   argument: ARGUMENT
   
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/optional/man.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/man.txt
@@ -21,9 +21,6 @@ optional (-h|--help)
   argument: ARGUMENT
   
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help Show this help text               
   --version Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/optional/man.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-optional (-h|--help) | --version | ARGUMENT
+optional (-h|--help) 
+ | --version 
+ | ARGUMENT
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/optional/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/opt-short.txt
@@ -1,1 +1,3 @@
-[33moptional[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [33mARGUMENT[m
+[33moptional[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [33mARGUMENT[m

--- a/opt-env-conf-test/test_resources/docs/optional/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/reference.txt
@@ -13,6 +13,9 @@
   argument: [33mARGUMENT[m
   
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/optional/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/reference.txt
@@ -13,9 +13,6 @@
   argument: [33mARGUMENT[m
   
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m               
   [37m--version[m [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/optional/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/optional/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33moptional[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [33mARGUMENT[m
+[36mUsage: [m[33moptional[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [33mARGUMENT[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
@@ -1,6 +1,8 @@
-[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-   [35mtop[m [37m--name[m [33mNAME[m [36m
- |[m [35msub[m [36m([m [35ma[m [36m|[m [35mb[m [36m)[m [36m([m [35mc[m [36m|[m [35md[m [36m)[m[36m)[m
+[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+     [35mtop[m [36m
+   |[m [35msub[m[36m)[m
 
 example with subcommands
 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
@@ -17,6 +17,6 @@ example with subcommands
   
 
 [36mAvailable commands[m:
-  [35mtop[m		[34mcommand without subcommands[m
-  [35msub[m		[34mcommand with subcommands[m
+  [35mtop[m       [34mcommand without subcommands[m
+  [35msub[m       [34mcommand with subcommands[m
 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
@@ -1,8 +1,6 @@
 [36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
  |[m [37m--version[m [36m
- |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-     [35mtop[m [36m
-   |[m [35msub[m[36m)[m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m COMMAND[36m)[m
 
 example with subcommands
 
@@ -17,29 +15,8 @@ example with subcommands
   option: [37m--config-file[m [33mFILE_PATH[m
   env: [37mCONFIG_FILE[m [33mFILE_PATH[m
   
-  [34mcommand without subcommands[m
-  command: [35mtop[m
-    [34mname[m
-    option: [37m--name[m [33mNAME[m
-    env: [37mNAME[m [33mNAME[m
-    config:
-      [37mname[m: # [32mor null[m
-        [33m<string>[m
-    
-  
-  [34mcommand with subcommands[m
-  command: [35msub[m
-    [34mA[m
-    command: [35ma[m
-    
-    [34mB[m
-    command: [35mb[m
-    
-    [34mC[m
-    command: [35mc[m
-    
-    [34mD[m
-    command: [35md[m
-    
-  
+
+[36mAvailable commands[m:
+  [35mtop[m		[34mcommand without subcommands[m
+  [35msub[m		[34mcommand with subcommands[m
 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
@@ -17,6 +17,6 @@ example with subcommands
   
 
 [36mAvailable commands[m:
-  [35mtop[m       [34mcommand without subcommands[m
-  [35msub[m       [34mcommand with subcommands[m
+  [35mtop[m   [34mcommand without subcommands[m
+  [35msub[m   [34mcommand with subcommands[m   
 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [35mtop[m [37m--name[m [33mNAME[m [36m|[m [35msub[m [35ma[m [36m|[m [35mb[m [35mc[m [36m|[m [35md[m[36m)[m
+[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+   [35mtop[m [37m--name[m [33mNAME[m [36m
+ |[m [35msub[m [36m([m [35ma[m [36m|[m [35mb[m [36m)[m [36m([m [35mc[m [36m|[m [35md[m [36m)[m[36m)[m
 
 example with subcommands
 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
@@ -9,9 +9,7 @@
 .Sh SYNOPSIS
 sub-commands (-h|--help) 
  | --version 
- | (--config-file FILE_PATH 
-     top 
-   | sub)
+ | (--config-file FILE_PATH COMMAND)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help
@@ -23,31 +21,10 @@ sub-commands (-h|--help)
   option: --config-file FILE_PATH
   env: CONFIG_FILE FILE_PATH
   
-  command without subcommands
-  command: top
-    name
-    option: --name NAME
-    env: NAME NAME
-    config:
-      name: # or null
-        <string>
-    
-  
-  command with subcommands
-  command: sub
-    A
-    command: a
-    
-    B
-    command: b
-    
-    C
-    command: c
-    
-    D
-    command: d
-    
-  
+
+.Sh COMMANDS
+  top		command without subcommands
+  sub		command with subcommands
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-sub-commands (-h|--help) | --version | (--config-file FILE_PATH top --name NAME | sub a | b c | d)
+sub-commands (-h|--help) | --version | (--config-file FILE_PATH 
+   top --name NAME 
+ | sub ( a | b ) ( c | d ))
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
@@ -23,30 +23,25 @@ sub-commands (-h|--help)
   
 
 .Sh COMMANDS
-  Show this help text
-  switch: -h|--help
-
-  Output version information: 0.0.0
-  switch: --version
-
   command without subcommands
   command: top
-  
+    name
+    option: --name NAME
+    env: NAME NAME
+    config:
+      name: # or null
+        <string>
+    
   command with subcommands
   command: sub
     A
     command: a
-    
     B
     command: b
-    
     C
     command: c
-    
     D
     command: d
-    
-  
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
@@ -23,8 +23,8 @@ sub-commands (-h|--help)
   
 
 .Sh COMMANDS
-  top		command without subcommands
-  sub		command with subcommands
+  top       command without subcommands
+  sub       command with subcommands
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
@@ -7,9 +7,11 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-sub-commands (-h|--help) | --version | (--config-file FILE_PATH 
-   top --name NAME 
- | sub ( a | b ) ( c | d ))
+sub-commands (-h|--help) 
+ | --version 
+ | (--config-file FILE_PATH 
+     top 
+   | sub)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
@@ -23,8 +23,30 @@ sub-commands (-h|--help)
   
 
 .Sh COMMANDS
-  top       command without subcommands
-  sub       command with subcommands
+  Show this help text
+  switch: -h|--help
+
+  Output version information: 0.0.0
+  switch: --version
+
+  command without subcommands
+  command: top
+  
+  command with subcommands
+  command: sub
+    A
+    command: a
+    
+    B
+    command: b
+    
+    C
+    command: c
+    
+    D
+    command: d
+    
+  
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/man.txt
@@ -32,16 +32,22 @@ sub-commands (-h|--help)
       name: # or null
         <string>
     
+  
   command with subcommands
   command: sub
     A
     command: a
+    
     B
     command: b
+    
     C
     command: c
+    
     D
     command: d
+    
+  
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/opt-short.txt
@@ -1,1 +1,3 @@
-[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [35mtop[m [37m--name[m [33mNAME[m [36m|[m [35msub[m [35ma[m [36m|[m [35mb[m [35mc[m [36m|[m [35md[m[36m)[m
+[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+   [35mtop[m [37m--name[m [33mNAME[m [36m
+ |[m [35msub[m [36m([m [35ma[m [36m|[m [35mb[m [36m)[m [36m([m [35mc[m [36m|[m [35md[m [36m)[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/sub-commands/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/opt-short.txt
@@ -1,5 +1,3 @@
 [33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
  |[m [37m--version[m [36m
- |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-     [35mtop[m [36m
-   |[m [35msub[m[36m)[m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m COMMAND[36m)[m

--- a/opt-env-conf-test/test_resources/docs/sub-commands/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/opt-short.txt
@@ -1,3 +1,5 @@
-[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-   [35mtop[m [37m--name[m [33mNAME[m [36m
- |[m [35msub[m [36m([m [35ma[m [36m|[m [35mb[m [36m)[m [36m([m [35mc[m [36m|[m [35md[m [36m)[m[36m)[m
+[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+     [35mtop[m [36m
+   |[m [35msub[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
@@ -15,8 +15,30 @@
   
 
 [36mAll commands[m:
-  [35mtop[m       [34mcommand without subcommands[m
-  [35msub[m       [34mcommand with subcommands[m
+  [34mShow this help text[m
+  switch: [37m-h[m[36m|[m[37m--help[m
+
+  [34mOutput version information: 0.0.0[m
+  switch: [37m--version[m
+
+  [34mcommand without subcommands[m
+  command: [35mtop[m
+  
+  [34mcommand with subcommands[m
+  command: [35msub[m
+    [34mA[m
+    command: [35ma[m
+    
+    [34mB[m
+    command: [35mb[m
+    
+    [34mC[m
+    command: [35mc[m
+    
+    [34mD[m
+    command: [35md[m
+    
+  
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
@@ -15,30 +15,25 @@
   
 
 [36mAll commands[m:
-  [34mShow this help text[m
-  switch: [37m-h[m[36m|[m[37m--help[m
-
-  [34mOutput version information: 0.0.0[m
-  switch: [37m--version[m
-
   [34mcommand without subcommands[m
   command: [35mtop[m
-  
+    [34mname[m
+    option: [37m--name[m [33mNAME[m
+    env: [37mNAME[m [33mNAME[m
+    config:
+      [37mname[m: # [32mor null[m
+        [33m<string>[m
+    
   [34mcommand with subcommands[m
   command: [35msub[m
     [34mA[m
     command: [35ma[m
-    
     [34mB[m
     command: [35mb[m
-    
     [34mC[m
     command: [35mc[m
-    
     [34mD[m
     command: [35md[m
-    
-  
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
@@ -1,8 +1,6 @@
 [36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
  |[m [37m--version[m [36m
- |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-     [35mtop[m [36m
-   |[m [35msub[m[36m)[m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m COMMAND[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m
@@ -15,31 +13,10 @@
   option: [37m--config-file[m [33mFILE_PATH[m
   env: [37mCONFIG_FILE[m [33mFILE_PATH[m
   
-  [34mcommand without subcommands[m
-  command: [35mtop[m
-    [34mname[m
-    option: [37m--name[m [33mNAME[m
-    env: [37mNAME[m [33mNAME[m
-    config:
-      [37mname[m: # [32mor null[m
-        [33m<string>[m
-    
-  
-  [34mcommand with subcommands[m
-  command: [35msub[m
-    [34mA[m
-    command: [35ma[m
-    
-    [34mB[m
-    command: [35mb[m
-    
-    [34mC[m
-    command: [35mc[m
-    
-    [34mD[m
-    command: [35md[m
-    
-  
+
+[36mAll commands[m:
+  [35mtop[m		[34mcommand without subcommands[m
+  [35msub[m		[34mcommand with subcommands[m
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [35mtop[m [37m--name[m [33mNAME[m [36m|[m [35msub[m [35ma[m [36m|[m [35mb[m [35mc[m [36m|[m [35md[m[36m)[m
+[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+   [35mtop[m [37m--name[m [33mNAME[m [36m
+ |[m [35msub[m [36m([m [35ma[m [36m|[m [35mb[m [36m)[m [36m([m [35mc[m [36m|[m [35md[m [36m)[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
@@ -15,8 +15,8 @@
   
 
 [36mAll commands[m:
-  [35mtop[m		[34mcommand without subcommands[m
-  [35msub[m		[34mcommand with subcommands[m
+  [35mtop[m       [34mcommand without subcommands[m
+  [35msub[m       [34mcommand with subcommands[m
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
@@ -1,6 +1,8 @@
-[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-   [35mtop[m [37m--name[m [33mNAME[m [36m
- |[m [35msub[m [36m([m [35ma[m [36m|[m [35mb[m [36m)[m [36m([m [35mc[m [36m|[m [35md[m [36m)[m[36m)[m
+[36mUsage: [m[33msub-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+     [35mtop[m [36m
+   |[m [35msub[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/sub-commands/reference.txt
@@ -24,16 +24,22 @@
       [37mname[m: # [32mor null[m
         [33m<string>[m
     
+  
   [34mcommand with subcommands[m
   command: [35msub[m
     [34mA[m
     command: [35ma[m
+    
     [34mB[m
     command: [35mb[m
+    
     [34mC[m
     command: [35mc[m
+    
     [34mD[m
     command: [35md[m
+    
+  
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/three-commands/config-docs.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/config-docs.txt
@@ -34,7 +34,7 @@ AnyDocsAnd
                 ]
           }
       , CommandDoc
-          { commandDocArgument = "three"
+          { commandDocArgument = "three-very-long-command-name"
           , commandDocHelp = "third"
           , commandDocs = AnyDocsAnd []
           }

--- a/opt-env-conf-test/test_resources/docs/three-commands/docs.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/docs.txt
@@ -103,7 +103,7 @@ AnyDocsAnd
                 ]
           }
       , CommandDoc
-          { commandDocArgument = "three"
+          { commandDocArgument = "three-very-long-command-name"
           , commandDocHelp = "third"
           , commandDocs = AnyDocsAnd []
           }

--- a/opt-env-conf-test/test_resources/docs/three-commands/env-docs.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/env-docs.txt
@@ -38,7 +38,7 @@ AnyDocsCommands
             ]
       }
   , CommandDoc
-      { commandDocArgument = "three"
+      { commandDocArgument = "three-very-long-command-name"
       , commandDocHelp = "third"
       , commandDocs = AnyDocsAnd []
       }

--- a/opt-env-conf-test/test_resources/docs/three-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/help.txt
@@ -17,8 +17,7 @@ example with three commands
   
 
 [36mAvailable commands[m:
-  [35mone[m                      [34mfirst[m
-  [35mtwo[m                      [34msecond[m
-  [35mthree-very-long-command-name[m
-                           [34mthird[m
+  [35mone[m                            [34mfirst[m 
+  [35mtwo[m                            [34msecond[m
+  [35mthree-very-long-command-name[m   [34mthird[m 
 

--- a/opt-env-conf-test/test_resources/docs/three-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/help.txt
@@ -1,4 +1,7 @@
-[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [35mone[m [33mSTR[m [36m|[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m|[m [35mthree[m[36m)[m
+[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+   [35mone[m [33mSTR[m [36m
+ |[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m
+ |[m [35mthree[m[36m)[m
 
 example with three commands
 

--- a/opt-env-conf-test/test_resources/docs/three-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/help.txt
@@ -1,7 +1,9 @@
-[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-   [35mone[m [33mSTR[m [36m
- |[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m
- |[m [35mthree[m[36m)[m
+[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+     [35mone[m [36m
+   |[m [35mtwo[m [36m
+   |[m [35mthree[m[36m)[m
 
 example with three commands
 

--- a/opt-env-conf-test/test_resources/docs/three-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/help.txt
@@ -1,9 +1,6 @@
 [36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
  |[m [37m--version[m [36m
- |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-     [35mone[m [36m
-   |[m [35mtwo[m [36m
-   |[m [35mthree[m[36m)[m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m COMMAND[36m)[m
 
 example with three commands
 
@@ -18,30 +15,9 @@ example with three commands
   option: [37m--config-file[m [33mFILE_PATH[m
   env: [37mCONFIG_FILE[m [33mFILE_PATH[m
   
-  [34mfirst[m
-  command: [35mone[m
-    [34margument[m
-    argument: [33mSTR[m
-    
-  
-  [34msecond[m
-  command: [35mtwo[m
-    [34mnumber[m
-    option: [37m--number[m[36m|[m[37m-n[m [33mINT[m
-    env: [37mNUMBER[m [33mINT[m
-    config:
-      [37mnumber[m: # [32mor null[m
-        [33m<number>[m # [32m64 bit signed integer[m
-    
-    [34menable extra[m
-    switch: [37m--(enable|disable)-enable[m
-    env: [37mENABLE[m [33mBOOL[m
-    config:
-      [37menable[m: # [32mor null[m
-        [33m<boolean>[m
-  
-  
-  [34mthird[m
-  command: [35mthree[m
-  
+
+[36mAvailable commands[m:
+  [35mone[m		[34mfirst[m
+  [35mtwo[m		[34msecond[m
+  [35mthree[m		[34mthird[m
 

--- a/opt-env-conf-test/test_resources/docs/three-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/help.txt
@@ -17,7 +17,7 @@ example with three commands
   
 
 [36mAvailable commands[m:
-  [35mone[m		[34mfirst[m
-  [35mtwo[m		[34msecond[m
-  [35mthree[m		[34mthird[m
+  [35mone[m       [34mfirst[m
+  [35mtwo[m       [34msecond[m
+  [35mthree[m     [34mthird[m
 

--- a/opt-env-conf-test/test_resources/docs/three-commands/help.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/help.txt
@@ -17,7 +17,8 @@ example with three commands
   
 
 [36mAvailable commands[m:
-  [35mone[m       [34mfirst[m
-  [35mtwo[m       [34msecond[m
-  [35mthree[m     [34mthird[m
+  [35mone[m                      [34mfirst[m
+  [35mtwo[m                      [34msecond[m
+  [35mthree-very-long-command-name[m
+                           [34mthird[m
 

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -9,10 +9,7 @@
 .Sh SYNOPSIS
 three-commands (-h|--help) 
  | --version 
- | (--config-file FILE_PATH 
-     one 
-   | two 
-   | three)
+ | (--config-file FILE_PATH COMMAND)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help
@@ -24,32 +21,11 @@ three-commands (-h|--help)
   option: --config-file FILE_PATH
   env: CONFIG_FILE FILE_PATH
   
-  first
-  command: one
-    argument
-    argument: STR
-    
-  
-  second
-  command: two
-    number
-    option: --number|-n INT
-    env: NUMBER INT
-    config:
-      number: # or null
-        <number> # 64 bit signed integer
-    
-    enable extra
-    switch: --(enable|disable)-enable
-    env: ENABLE BOOL
-    config:
-      enable: # or null
-        <boolean>
-  
-  
-  third
-  command: three
-  
+
+.Sh COMMANDS
+  one		first
+  two		second
+  three		third
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -7,7 +7,10 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-three-commands (-h|--help) | --version | (--config-file FILE_PATH one STR | two --number|-n INT --(enable|disable)-enable | three)
+three-commands (-h|--help) | --version | (--config-file FILE_PATH 
+   one STR 
+ | two --number|-n INT --(enable|disable)-enable 
+ | three)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -28,6 +28,7 @@ three-commands (-h|--help)
     argument
     argument: STR
     
+  
   second
   command: two
     number
@@ -44,8 +45,10 @@ three-commands (-h|--help)
       enable: # or null
         <boolean>
   
+  
   third
   command: three-very-long-command-name
+  
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -23,9 +23,10 @@ three-commands (-h|--help)
   
 
 .Sh COMMANDS
-  one       first
-  two       second
-  three     third
+  one                      first
+  two                      second
+  three-very-long-command-name
+                           third
 
 .Sh OPTIONS
   -h|--help Show this help text 
@@ -36,7 +37,7 @@ three-commands (-h|--help)
   two second
       --number|-n               number       
       --(enable|disable)-enable enable extra 
-  three third
+  three-very-long-command-name third
 
 .Sh ENVIRONMENT VARIABLES
   CONFIG_FILE FILE_PATH   Path to the configuration file

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -7,10 +7,12 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-three-commands (-h|--help) | --version | (--config-file FILE_PATH 
-   one STR 
- | two --number|-n INT --(enable|disable)-enable 
- | three)
+three-commands (-h|--help) 
+ | --version 
+ | (--config-file FILE_PATH 
+     one 
+   | two 
+   | three)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -23,10 +23,28 @@ three-commands (-h|--help)
   
 
 .Sh COMMANDS
-  one                      first
-  two                      second
-  three-very-long-command-name
-                           third
+  Show this help text
+  switch: -h|--help
+
+  Output version information: 0.0.0
+  switch: --version
+
+  first
+  command: one
+  
+  second
+  command: two
+    enable extra
+    switch: --(enable|disable)-enable
+    env: ENABLE BOOL
+    config:
+      enable: # or null
+        <boolean>
+  
+  
+  third
+  command: three-very-long-command-name
+  
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -23,17 +23,20 @@ three-commands (-h|--help)
   
 
 .Sh COMMANDS
-  Show this help text
-  switch: -h|--help
-
-  Output version information: 0.0.0
-  switch: --version
-
   first
   command: one
-  
+    argument
+    argument: STR
+    
   second
   command: two
+    number
+    option: --number|-n INT
+    env: NUMBER INT
+    config:
+      number: # or null
+        <number> # 64 bit signed integer
+    
     enable extra
     switch: --(enable|disable)-enable
     env: ENABLE BOOL
@@ -41,10 +44,8 @@ three-commands (-h|--help)
       enable: # or null
         <boolean>
   
-  
   third
   command: three-very-long-command-name
-  
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/three-commands/man.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/man.txt
@@ -23,9 +23,9 @@ three-commands (-h|--help)
   
 
 .Sh COMMANDS
-  one		first
-  two		second
-  three		third
+  one       first
+  two       second
+  three     third
 
 .Sh OPTIONS
   -h|--help Show this help text 

--- a/opt-env-conf-test/test_resources/docs/three-commands/opt-docs.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/opt-docs.txt
@@ -53,7 +53,7 @@ AnyDocsAnd
                 ]
           }
       , CommandDoc
-          { commandDocArgument = "three"
+          { commandDocArgument = "three-very-long-command-name"
           , commandDocHelp = "third"
           , commandDocs = AnyDocsAnd []
           }

--- a/opt-env-conf-test/test_resources/docs/three-commands/opt-long.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/opt-long.txt
@@ -6,4 +6,4 @@
   [35mtwo[m [34msecond[m
       [37m--number[m[36m|[m[37m-n[m               [34mnumber[m       
       [37m--(enable|disable)-enable[m [34menable extra[m 
-  [35mthree[m [34mthird[m
+  [35mthree-very-long-command-name[m [34mthird[m

--- a/opt-env-conf-test/test_resources/docs/three-commands/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/opt-short.txt
@@ -1,6 +1,3 @@
 [33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
  |[m [37m--version[m [36m
- |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-     [35mone[m [36m
-   |[m [35mtwo[m [36m
-   |[m [35mthree[m[36m)[m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m COMMAND[36m)[m

--- a/opt-env-conf-test/test_resources/docs/three-commands/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/opt-short.txt
@@ -1,4 +1,6 @@
-[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-   [35mone[m [33mSTR[m [36m
- |[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m
- |[m [35mthree[m[36m)[m
+[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+     [35mone[m [36m
+   |[m [35mtwo[m [36m
+   |[m [35mthree[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/three-commands/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/opt-short.txt
@@ -1,1 +1,4 @@
-[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [35mone[m [33mSTR[m [36m|[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m|[m [35mthree[m[36m)[m
+[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+   [35mone[m [33mSTR[m [36m
+ |[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m
+ |[m [35mthree[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -20,6 +20,7 @@
     [34margument[m
     argument: [33mSTR[m
     
+  
   [34msecond[m
   command: [35mtwo[m
     [34mnumber[m
@@ -36,8 +37,10 @@
       [37menable[m: # [32mor null[m
         [33m<boolean>[m
   
+  
   [34mthird[m
   command: [35mthree-very-long-command-name[m
+  
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -1,9 +1,6 @@
 [36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
  |[m [37m--version[m [36m
- |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-     [35mone[m [36m
-   |[m [35mtwo[m [36m
-   |[m [35mthree[m[36m)[m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m COMMAND[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m
@@ -16,32 +13,11 @@
   option: [37m--config-file[m [33mFILE_PATH[m
   env: [37mCONFIG_FILE[m [33mFILE_PATH[m
   
-  [34mfirst[m
-  command: [35mone[m
-    [34margument[m
-    argument: [33mSTR[m
-    
-  
-  [34msecond[m
-  command: [35mtwo[m
-    [34mnumber[m
-    option: [37m--number[m[36m|[m[37m-n[m [33mINT[m
-    env: [37mNUMBER[m [33mINT[m
-    config:
-      [37mnumber[m: # [32mor null[m
-        [33m<number>[m # [32m64 bit signed integer[m
-    
-    [34menable extra[m
-    switch: [37m--(enable|disable)-enable[m
-    env: [37mENABLE[m [33mBOOL[m
-    config:
-      [37menable[m: # [32mor null[m
-        [33m<boolean>[m
-  
-  
-  [34mthird[m
-  command: [35mthree[m
-  
+
+[36mAll commands[m:
+  [35mone[m		[34mfirst[m
+  [35mtwo[m		[34msecond[m
+  [35mthree[m		[34mthird[m
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -1,4 +1,7 @@
-[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [35mone[m [33mSTR[m [36m|[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m|[m [35mthree[m[36m)[m
+[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+   [35mone[m [33mSTR[m [36m
+ |[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m
+ |[m [35mthree[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -15,10 +15,28 @@
   
 
 [36mAll commands[m:
-  [35mone[m                      [34mfirst[m
-  [35mtwo[m                      [34msecond[m
-  [35mthree-very-long-command-name[m
-                           [34mthird[m
+  [34mShow this help text[m
+  switch: [37m-h[m[36m|[m[37m--help[m
+
+  [34mOutput version information: 0.0.0[m
+  switch: [37m--version[m
+
+  [34mfirst[m
+  command: [35mone[m
+  
+  [34msecond[m
+  command: [35mtwo[m
+    [34menable extra[m
+    switch: [37m--(enable|disable)-enable[m
+    env: [37mENABLE[m [33mBOOL[m
+    config:
+      [37menable[m: # [32mor null[m
+        [33m<boolean>[m
+  
+  
+  [34mthird[m
+  command: [35mthree-very-long-command-name[m
+  
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -15,9 +15,10 @@
   
 
 [36mAll commands[m:
-  [35mone[m       [34mfirst[m
-  [35mtwo[m       [34msecond[m
-  [35mthree[m     [34mthird[m
+  [35mone[m                      [34mfirst[m
+  [35mtwo[m                      [34msecond[m
+  [35mthree-very-long-command-name[m
+                           [34mthird[m
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 
@@ -28,7 +29,7 @@
   [35mtwo[m [34msecond[m
       [37m--number[m[36m|[m[37m-n[m               [34mnumber[m       
       [37m--(enable|disable)-enable[m [34menable extra[m 
-  [35mthree[m [34mthird[m
+  [35mthree-very-long-command-name[m [34mthird[m
 
 [36mEnvironment Variables[m:
   [37mCONFIG_FILE[m [33mFILE_PATH[m   [34mPath to the configuration file[m

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -15,9 +15,9 @@
   
 
 [36mAll commands[m:
-  [35mone[m		[34mfirst[m
-  [35mtwo[m		[34msecond[m
-  [35mthree[m		[34mthird[m
+  [35mone[m       [34mfirst[m
+  [35mtwo[m       [34msecond[m
+  [35mthree[m     [34mthird[m
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -1,7 +1,9 @@
-[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
-   [35mone[m [33mSTR[m [36m
- |[m [35mtwo[m [37m--number[m[36m|[m[37m-n[m [33mINT[m [37m--(enable|disable)-enable[m [36m
- |[m [35mthree[m[36m)[m
+[36mUsage: [m[33mthree-commands[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m 
+     [35mone[m [36m
+   |[m [35mtwo[m [36m
+   |[m [35mthree[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/reference.txt
@@ -15,17 +15,20 @@
   
 
 [36mAll commands[m:
-  [34mShow this help text[m
-  switch: [37m-h[m[36m|[m[37m--help[m
-
-  [34mOutput version information: 0.0.0[m
-  switch: [37m--version[m
-
   [34mfirst[m
   command: [35mone[m
-  
+    [34margument[m
+    argument: [33mSTR[m
+    
   [34msecond[m
   command: [35mtwo[m
+    [34mnumber[m
+    option: [37m--number[m[36m|[m[37m-n[m [33mINT[m
+    env: [37mNUMBER[m [33mINT[m
+    config:
+      [37mnumber[m: # [32mor null[m
+        [33m<number>[m # [32m64 bit signed integer[m
+    
     [34menable extra[m
     switch: [37m--(enable|disable)-enable[m
     env: [37mENABLE[m [33mBOOL[m
@@ -33,10 +36,8 @@
       [37menable[m: # [32mor null[m
         [33m<boolean>[m
   
-  
   [34mthird[m
   command: [35mthree-very-long-command-name[m
-  
 
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m 

--- a/opt-env-conf-test/test_resources/docs/three-commands/show.txt
+++ b/opt-env-conf-test/test_resources/docs/three-commands/show.txt
@@ -173,5 +173,5 @@ WithConfig
                                  Nothing
                                  (Just "enable extra")))
                            (Pure _)))))))
-     , Command "three" "third" (Pure _)
+     , Command "three-very-long-command-name" "third" (Pure _)
      ])

--- a/opt-env-conf-test/test_resources/docs/verbose/help.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/help.txt
@@ -15,3 +15,6 @@ verbosity example
   switch: [37m-v[m
   
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/verbose/help.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/help.txt
@@ -15,6 +15,3 @@ verbosity example
   switch: [37m-v[m
   
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/verbose/help.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33mverbose[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [37m-v[m
+[36mUsage: [m[33mverbose[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [37m-v[m
 
 verbosity example
 

--- a/opt-env-conf-test/test_resources/docs/verbose/man.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/man.txt
@@ -21,9 +21,6 @@ verbose (-h|--help)
   switch: -v
   
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help Show this help text                                 
   --version Output version information: 0.0.0                   

--- a/opt-env-conf-test/test_resources/docs/verbose/man.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-verbose (-h|--help) | --version | -v
+verbose (-h|--help) 
+ | --version 
+ | -v
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/verbose/man.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/man.txt
@@ -21,6 +21,9 @@ verbose (-h|--help)
   switch: -v
   
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help Show this help text                                 
   --version Output version information: 0.0.0                   

--- a/opt-env-conf-test/test_resources/docs/verbose/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/opt-short.txt
@@ -1,1 +1,3 @@
-[33mverbose[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [37m-v[m
+[33mverbose[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [37m-v[m

--- a/opt-env-conf-test/test_resources/docs/verbose/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/reference.txt
@@ -13,9 +13,6 @@
   switch: [37m-v[m
   
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m                                 
   [37m--version[m [34mOutput version information: 0.0.0[m                   

--- a/opt-env-conf-test/test_resources/docs/verbose/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33mverbose[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [37m-v[m
+[36mUsage: [m[33mverbose[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [37m-v[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/verbose/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/verbose/reference.txt
@@ -13,6 +13,9 @@
   switch: [37m-v[m
   
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m [34mShow this help text[m                                 
   [37m--version[m [34mOutput version information: 0.0.0[m                   

--- a/opt-env-conf-test/test_resources/docs/yes-no/help.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/help.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33myes-no[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--[no-]example[m[36m)[m
+[36mUsage: [m[33myes-no[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--[no-]example[m[36m)[m
 
 yesNoSwitch example
 

--- a/opt-env-conf-test/test_resources/docs/yes-no/help.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/help.txt
@@ -23,6 +23,3 @@ yesNoSwitch example
       [33m<boolean>[m
 
 
-[36mAvailable commands[m:
-no commands available
-

--- a/opt-env-conf-test/test_resources/docs/yes-no/help.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/help.txt
@@ -23,3 +23,6 @@ yesNoSwitch example
       [33m<boolean>[m
 
 
+[36mAvailable commands[m:
+no commands available
+

--- a/opt-env-conf-test/test_resources/docs/yes-no/man.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/man.txt
@@ -29,6 +29,9 @@ yes-no (-h|--help)
       <boolean>
 
 
+.Sh COMMANDS
+no commands available
+
 .Sh OPTIONS
   -h|--help      Show this help text               
   --version      Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/yes-no/man.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/man.txt
@@ -29,9 +29,6 @@ yes-no (-h|--help)
       <boolean>
 
 
-.Sh COMMANDS
-no commands available
-
 .Sh OPTIONS
   -h|--help      Show this help text               
   --version      Output version information: 0.0.0 

--- a/opt-env-conf-test/test_resources/docs/yes-no/man.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/man.txt
@@ -7,7 +7,9 @@
 .Sh VERSION
 0.0.0
 .Sh SYNOPSIS
-yes-no (-h|--help) | --version | (--config-file FILE_PATH --[no-]example)
+yes-no (-h|--help) 
+ | --version 
+ | (--config-file FILE_PATH --[no-]example)
 .Sh SETTINGS
   Show this help text
   switch: -h|--help

--- a/opt-env-conf-test/test_resources/docs/yes-no/opt-short.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/opt-short.txt
@@ -1,1 +1,3 @@
-[33myes-no[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--[no-]example[m[36m)[m
+[33myes-no[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--[no-]example[m[36m)[m

--- a/opt-env-conf-test/test_resources/docs/yes-no/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/reference.txt
@@ -1,4 +1,6 @@
-[36mUsage: [m[33myes-no[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m|[m [37m--version[m [36m|[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--[no-]example[m[36m)[m
+[36mUsage: [m[33myes-no[m [36m([m[37m-h[m[36m|[m[37m--help[m[36m)[m [36m
+ |[m [37m--version[m [36m
+ |[m [36m([m[37m--config-file[m [33mFILE_PATH[m [37m--[no-]example[m[36m)[m
 
 [36mAll settings[m:
   [34mShow this help text[m

--- a/opt-env-conf-test/test_resources/docs/yes-no/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/reference.txt
@@ -21,9 +21,6 @@
       [33m<boolean>[m
 
 
-[36mAll commands[m:
-no commands available
-
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m      [34mShow this help text[m               
   [37m--version[m      [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf-test/test_resources/docs/yes-no/reference.txt
+++ b/opt-env-conf-test/test_resources/docs/yes-no/reference.txt
@@ -21,6 +21,9 @@
       [33m<boolean>[m
 
 
+[36mAll commands[m:
+no commands available
+
 [36mOptions[m:
   [37m-h[m[36m|[m[37m--help[m      [34mShow this help text[m               
   [37m--version[m      [34mOutput version information: 0.0.0[m 

--- a/opt-env-conf/src/OptEnvConf/Doc.hs
+++ b/opt-env-conf/src/OptEnvConf/Doc.hs
@@ -469,7 +469,7 @@ renderCommandDocs = unlinesChunks . (\cs -> if null cs then [["no commands avail
     goCommand maxLength CommandDoc {..} =
       indent $
         if length commandDocArgument <= maxLength' - 1
-          then [commandChunk commandDocArgument, chunk (T.replicate (maxLength' - length commandDocArgument) " "), helpChunk commandDocHelp] : []
+          then [[commandChunk commandDocArgument, chunk (T.replicate (maxLength' - length commandDocArgument) " "), helpChunk commandDocHelp]]
           else [commandChunk commandDocArgument] : [[chunk (T.replicate maxLength' " "), helpChunk commandDocHelp]]
       where
         maxLength' = minimum [25, maximum [10, maxLength]]
@@ -479,26 +479,7 @@ renderCommandDocs = unlinesChunks . (\cs -> if null cs then [["no commands avail
     goOr = \case
       [] -> []
       [d] -> go d
-      (AnyDocsSingle d : ds) ->
-        case setDocHelp d of
-          Nothing -> go (AnyDocsSingle d) ++ goOr ds
-          Just h ->
-            let (_, rest) = goSameHelp h ds
-             in concat
-                  [  goOr rest
-                  ]
       (d : ds) -> go d ++ goOr ds
-
-    goSameHelp :: Help -> [AnyDocs SetDoc] -> ([SetDoc], [AnyDocs SetDoc])
-    goSameHelp h = \case
-      [] -> ([], [])
-      (AnyDocsSingle d : ds) ->
-        if setDocHelp d == Just h
-          then
-            let (sds, rest) = goSameHelp h ds
-             in (d : sds, rest)
-          else ([], AnyDocsSingle d : ds)
-      ds -> ([], ds)
 
 parserOptDocs :: Parser a -> AnyDocs OptDoc
 parserOptDocs = docsToOptDocs . parserDocs
@@ -524,7 +505,7 @@ renderShortOptDocs progname = unwordsChunks . (\cs -> [[progNameChunk progname],
   where
     go :: Int -> AnyDocs OptDoc -> [Chunk]
     go nestingLevel = \case
-      AnyDocsCommands _ -> unwordsChunks $ [["COMMAND"]]
+      AnyDocsCommands _ -> ["COMMAND"]
       AnyDocsAnd ds -> unwordsChunks $ map (go (nestingLevel + 1)) ds
       AnyDocsOr ds -> renderOrChunks $ map (go (nestingLevel + 1)) ds
       AnyDocsSingle OptDoc {..} ->

--- a/opt-env-conf/src/OptEnvConf/Doc.hs
+++ b/opt-env-conf/src/OptEnvConf/Doc.hs
@@ -522,25 +522,18 @@ renderCommandDocs = unlinesChunks . go True
       ds -> ([], ds)
 
 renderCommandDocsShort :: AnyDocs SetDoc -> [Chunk]
-renderCommandDocsShort = unlinesChunks . go
+renderCommandDocsShort = layoutAsTable .  go
   where
-    go :: AnyDocs SetDoc -> [[Chunk]]
+    go :: AnyDocs SetDoc -> [[[Chunk]]]
     go = \case
-      AnyDocsCommands cs ->
-        let maxLength = maximum $ length . commandDocArgument <$> cs
-         in concatMap (goCommand maxLength) cs
+      AnyDocsCommands cs -> concatMap goCommand cs
       AnyDocsAnd ds -> concatMap go ds
       AnyDocsOr ds -> concatMap go ds
       AnyDocsSingle _ -> []
 
-    goCommand :: Int -> CommandDoc SetDoc -> [[Chunk]]
-    goCommand maxLength CommandDoc {..} =
-      indent $
-        if length commandDocArgument <= maxLength' - 1
-          then [[commandChunk commandDocArgument, chunk (T.replicate (maxLength' - length commandDocArgument) " "), helpChunk commandDocHelp]]
-          else [commandChunk commandDocArgument] : [[chunk (T.replicate maxLength' " "), helpChunk commandDocHelp]]
-      where
-        maxLength' = minimum [25, maximum [10, maxLength]]
+    goCommand :: CommandDoc SetDoc -> [[[Chunk]]]
+    goCommand CommandDoc {..} =
+      [indent $ [[commandChunk commandDocArgument], [helpChunk commandDocHelp]]]
 
 parserOptDocs :: Parser a -> AnyDocs OptDoc
 parserOptDocs = docsToOptDocs . parserDocs

--- a/opt-env-conf/src/OptEnvConf/Doc.hs
+++ b/opt-env-conf/src/OptEnvConf/Doc.hs
@@ -478,7 +478,7 @@ renderCommandDocs = unlinesChunks . go
         let maxLength = maximum $ length . commandDocArgument <$> cs
          in concatMap (goCommand maxLength) cs
       AnyDocsAnd ds -> concatMap go ds
-      AnyDocsOr ds -> goOr ds
+      AnyDocsOr ds -> concatMap go ds
       AnyDocsSingle _ -> []
 
     goCommand :: Int -> CommandDoc SetDoc -> [[Chunk]]
@@ -489,13 +489,6 @@ renderCommandDocs = unlinesChunks . go
           else [commandChunk commandDocArgument] : [[chunk (T.replicate maxLength' " "), helpChunk commandDocHelp]]
       where
         maxLength' = minimum [25, maximum [10, maxLength]]
-
-    -- Group together settings with the same help (produced by combinators like enableDisableSwitch)
-    goOr :: [AnyDocs SetDoc] -> [[Chunk]]
-    goOr = \case
-      [] -> []
-      [d] -> go d
-      (d : ds) -> go d ++ goOr ds
 
 parserOptDocs :: Parser a -> AnyDocs OptDoc
 parserOptDocs = docsToOptDocs . parserDocs

--- a/opt-env-conf/src/OptEnvConf/Doc.hs
+++ b/opt-env-conf/src/OptEnvConf/Doc.hs
@@ -486,6 +486,7 @@ renderCommandDocs = unlinesChunks . go True
         [helpChunk commandDocHelp]
           : ["command: ", commandChunk commandDocArgument]
           : go False commandDocs
+          ++ [[]]
 
     -- Group together settings with the same help (produced by combinators like enableDisableSwitch)
     goOr :: Bool -> [AnyDocs SetDoc] -> [[Chunk]]


### PR DESCRIPTION
This is a first iteration towards a help text output that works better for parsers with nested commands.

I think what should be improved is the fact that now the braces around the commands and the rest of the mandatory fields are rather hard to parse (it's correct, but not easy to see).
Also, I thought about inserting line breaks between the help and version flags, but it makes things more difficult because we probably have to indent the commands then so it's clear which one's which. The same goes for parsers with deeper nested subcommands. There are braces around the different subcommands now (which helps in distinguishing them), but if the subcommands themselves require several configurations, things get messy again.