### PR TITLE
Optional arg and switch

### DIFF
--- a/opt-env-conf-test/opt-env-conf-test.cabal
+++ b/opt-env-conf-test/opt-env-conf-test.cabal
@@ -180,11 +180,16 @@ extra-source-files:
     test_resources/error/read-int-options.txt
     test_resources/error/required-command.txt
     test_resources/error/some-none.txt
+    test_resources/error/typo-option.txt
+    test_resources/error/typo-switch.txt
     test_resources/error/unfolding-tombstone-option.txt
     test_resources/error/unfolding-tombstone-switch.txt
     test_resources/error/unreadable-var.txt
     test_resources/error/unreadable-vars.txt
+    test_resources/error/unrecognised-arg.txt
     test_resources/error/unrecognised-command.txt
+    test_resources/error/unrecognised-option.txt
+    test_resources/error/unrecognised-switch.txt
     test_resources/lint/config-without-load.txt
     test_resources/lint/dash-in-long.txt
     test_resources/lint/dash-in-short.txt

--- a/opt-env-conf-test/test/OptEnvConf/ArgsSpec.hs
+++ b/opt-env-conf-test/test/OptEnvConf/ArgsSpec.hs
@@ -43,11 +43,7 @@ spec = do
 
   describe "consumeArgument" $ do
     it "does not consume anything if there is nothing to consume" $
-      consumeArgument [] `shouldBe` []
-    it "consumes any argument if there is only one" $
-      forAllValid $ \a ->
-        consumeArgument [Live a]
-          `shouldBe` [(renderArg a, [])]
+      consumeArgument [] `shouldBe` [(Nothing, emptyArgs)]
 
   describe "consumeOption" $ do
     it "fails to consume if there are no dasheds" $

--- a/opt-env-conf-test/test/OptEnvConf/ErrorSpec.hs
+++ b/opt-env-conf-test/test/OptEnvConf/ErrorSpec.hs
@@ -159,6 +159,29 @@ spec = do
     )
     ["--foo", "'a'"]
 
+  parseArgsErrorSpec
+    "unrecognised-arg"
+    (pure 'a')
+    ["arg"]
+  parseArgsErrorSpec
+    "unrecognised-option"
+    (pure 'b')
+    ["--foo", "bar"]
+  parseArgsErrorSpec
+    "unrecognised-switch"
+    (pure 'c')
+    ["--foo"]
+
+  parseArgsErrorSpec
+    "typo-option"
+    (optional $ setting [help "often misspelt as baz", reader str, option, long "bar"] :: Parser (Maybe String))
+    ["--baz", "arg"]
+
+  parseArgsErrorSpec
+    "typo-switch"
+    (optional $ setting [help "often misspelt as baz", switch True, long "bar"] :: Parser (Maybe Bool))
+    ["--baz"]
+
 parseArgsErrorSpec :: (HasCallStack) => (Show a) => FilePath -> Parser a -> [String] -> Spec
 parseArgsErrorSpec fp p args =
   withFrozenCallStack $

--- a/opt-env-conf-test/test/OptEnvConf/RunSpec.hs
+++ b/opt-env-conf-test/test/OptEnvConf/RunSpec.hs
@@ -499,6 +499,38 @@ spec = do
           (["-ffoo"], "foo")
         ]
 
+      -- Optional Argument and optional switch
+      argParseSpecs
+        ( (,)
+            <$> optional (setting [reader str, argument])
+            <*> setting [switch True, short 'w', long "watch", value False] ::
+            Parser (Maybe String, Bool)
+        )
+        [ (["foo", "-w"], (Just "foo", True)),
+          (["-w", "foo"], (Just "foo", True)),
+          (["foo", "--watch"], (Just "foo", True)),
+          (["--watch", "foo"], (Just "foo", True)),
+          (["foo"], (Just "foo", False)),
+          (["--bar"], (Just "--bar", False)),
+          (["-w"], (Nothing, True)),
+          (["--watch"], (Nothing, True))
+        ]
+      argParseSpecs
+        ( (,)
+            <$> setting [switch True, short 'w', long "watch", value False]
+            <*> optional (setting [reader str, argument]) ::
+            Parser (Bool, Maybe String)
+        )
+        [ (["foo", "-w"], (True, Just "foo")),
+          (["-w", "foo"], (True, Just "foo")),
+          (["foo", "--watch"], (True, Just "foo")),
+          (["--watch", "foo"], (True, Just "foo")),
+          (["foo"], (False, Just "foo")),
+          (["--bar"], (False, Just "--bar")),
+          (["-w"], (False, Nothing)),
+          (["--watch"], (False, Nothing))
+        ]
+
       argParseSpecs
         (enableDisableSwitch True [long "example", env "EXAMPLE", conf "example"])
         [ ([], True),

--- a/opt-env-conf-test/test/OptEnvConf/RunSpec.hs
+++ b/opt-env-conf-test/test/OptEnvConf/RunSpec.hs
@@ -28,49 +28,44 @@ spec = do
   describe "runParser" $ do
     describe "pure" $ do
       it "can parse a pure value from anything" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \expected ->
-                shouldParse (pure expected) args e mConf (expected :: Int)
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \expected ->
+              shouldParse (pure expected) Args.emptyArgs e mConf (expected :: Int)
 
     describe "fmap" $ do
       it "can parse a mapped value from anything" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \i -> do
-                let expected = succ i
-                shouldParse (fmap succ $ pure i) args e mConf (expected :: Int)
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \i -> do
+              let expected = succ i
+              shouldParse (fmap succ $ pure i) Args.emptyArgs e mConf (expected :: Int)
 
     describe "<*>" $ do
       it "can parse two values with ap" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \i -> do
-                let p = (,) <$> pure (succ i) <*> pure i
-                let expected = (succ i, i :: Int)
-                shouldParse p args e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \i -> do
+              let p = (,) <$> pure (succ i) <*> pure i
+              let expected = (succ i, i :: Int)
+              shouldParse p Args.emptyArgs e mConf expected
 
     describe "Select" $ do
       it "can use the second parser with select" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \i -> do
-                let p = select (pure (Left i :: Either Int Int)) (pure succ)
-                let expected = succ i
-                shouldParse p args e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \i -> do
+              let p = select (pure (Left i :: Either Int Int)) (pure succ)
+              let expected = succ i
+              shouldParse p Args.emptyArgs e mConf expected
 
       it "can avoid the second parser with select" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \i -> do
-                let p = select (pure (Right i :: Either Int Int)) (pure succ)
-                let expected = i
-                shouldParse p args e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \i -> do
+              let p = select (pure (Right i :: Either Int Int)) (pure succ)
+              let expected = i
+              shouldParse p Args.emptyArgs e mConf expected
 
     describe "Empty" $ do
       it "can fail to parse an empty value" $
@@ -84,22 +79,20 @@ spec = do
 
     describe "Alt" $ do
       it "can parse a Left value with Alt" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \i -> do
-                let p = (Left <$> pure i) <|> (Right <$> pure (succ i))
-                let expected = Left (i :: Int)
-                shouldParse p args e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \i -> do
+              let p = (Left <$> pure i) <|> (Right <$> pure (succ i))
+              let expected = Left (i :: Int)
+              shouldParse p Args.emptyArgs e mConf expected
 
       it "can parse a Right value with Alt" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \i -> do
-                let p = empty `ParserAlt` (Right <$> pure i)
-                let expected = Right (i :: Int) :: Either Int Int
-                shouldParse p args e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \i -> do
+              let p = empty `ParserAlt` (Right <$> pure i)
+              let expected = Right (i :: Int) :: Either Int Int
+              shouldParse p Args.emptyArgs e mConf expected
 
     describe "Many" $ do
       it "can pass many args" $
@@ -132,114 +125,106 @@ spec = do
 
     describe "MapIO" $ do
       it "can run an IO action on the result of a parser" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \i -> do
-                let p = mapIO (pure . succ) (pure (i :: Int))
-                let expected = succ i
-                shouldParse p args e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \i -> do
+              let p = mapIO (pure . succ) (pure (i :: Int))
+              let expected = succ i
+              shouldParse p Args.emptyArgs e mConf expected
 
     describe "WithConfig" $ do
       it "can replace the config object" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \c1 ->
-              forAllValid $ \c2' ->
-                forAllValid $ \(key, val) -> do
-                  let c2 = KeyMap.insert key (toJSON val) c2'
-                  let p =
-                        withConfig (pure (Just c2)) $
-                          setting [conf (Key.toString key)]
-                  let expected = val :: Text
-                  shouldParse p args e (Just c1) expected
+        forAllValid $ \e ->
+          forAllValid $ \c1 ->
+            forAllValid $ \c2' ->
+              forAllValid $ \(key, val) -> do
+                let c2 = KeyMap.insert key (toJSON val) c2'
+                let p =
+                      withConfig (pure (Just c2)) $
+                        setting [conf (Key.toString key)]
+                let expected = val :: Text
+                shouldParse p Args.emptyArgs e (Just c1) expected
 
     describe "withFirstYamlConfig" $ do
       it "can parse without any arguments" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \val -> do
-              let p = withFirstYamlConfig (pure []) (pure val) :: Parser String
-              shouldParse p args e Nothing val
+        forAllValid $ \e ->
+          forAllValid $ \val -> do
+            let p = withFirstYamlConfig (pure []) (pure val) :: Parser String
+            shouldParse p Args.emptyArgs e Nothing val
 
     describe "withCombinedYamlConfig" $ do
       it "can parse without any arguments" $ do
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \val -> do
-              let p = withCombinedYamlConfigs (pure []) (pure val) :: Parser String
-              shouldParse p args e Nothing val
+        forAllValid $ \e ->
+          forAllValid $ \val -> do
+            let p = withCombinedYamlConfigs (pure []) (pure val) :: Parser String
+            shouldParse p Args.emptyArgs e Nothing val
 
     describe "subArgs" $ do
       it "can prefix a switch parser" $
-        forAllValid $ \a' ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \prefix ->
-                forAllValid $ \(key, val) -> do
-                  let prefixedKey = Args.prefixDashed prefix (DashedLong key)
-                  let a = a' {unArgs = Live (Args.renderDashedArg prefixedKey) : unArgs a'}
-                  let p =
-                        subArgs prefix $
-                          setting
-                            [ reader str,
-                              switch val,
-                              long (NE.toList key)
-                            ]
-                  let expected = val :: String
-                  shouldParse p a e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \prefix ->
+              forAllValid $ \(key, val) -> do
+                let prefixedKey = Args.prefixDashed prefix (DashedLong key)
+                let a = Args.parseArgs [Args.renderDashed prefixedKey]
+                let p =
+                      subArgs prefix $
+                        setting
+                          [ reader str,
+                            switch val,
+                            long (NE.toList key)
+                          ]
+                let expected = val :: String
+                shouldParse p a e mConf expected
 
       it "can prefix an option parser" $
-        forAllValid $ \a' ->
-          forAllValid $ \e ->
-            forAllValid $ \mConf ->
-              forAllValid $ \prefix ->
-                forAllValid $ \(key, val) -> do
-                  let prefixedKey = Args.prefixDashed prefix (DashedLong key)
-                  let a = a' {unArgs = Live (Args.renderDashedArg prefixedKey) : Live (ArgPlain val) : unArgs a'}
-                  let p =
-                        subArgs prefix $
-                          setting
-                            [ reader str,
-                              option,
-                              long (NE.toList key)
-                            ]
-                  let expected = val
-                  shouldParse p a e mConf expected
+        forAllValid $ \e ->
+          forAllValid $ \mConf ->
+            forAllValid $ \prefix ->
+              forAllValid $ \(key, val) -> do
+                let prefixedKey = Args.prefixDashed prefix (DashedLong key)
+                let a = parseArgs [renderDashed prefixedKey, val]
+                let p =
+                      subArgs prefix $
+                        setting
+                          [ reader str,
+                            option,
+                            long (NE.toList key)
+                          ]
+                let expected = val
+                shouldParse p a e mConf expected
 
     describe "subEnv" $ do
       it "can prefix an env var parser" $
-        forAllValid $ \args ->
-          forAllValid $ \e' ->
-            forAllValid $ \mConf ->
-              forAllValid $ \prefix ->
-                forAllValid $ \(key, val) -> do
-                  let prefixedKey = prefix <> key
-                  let e = EnvMap.insert prefixedKey val e'
-                  let p = subEnv prefix $ setting [reader str, env key]
-                  let expected = val
-                  shouldParse p args e mConf expected
+        forAllValid $ \e' ->
+          forAllValid $ \mConf ->
+            forAllValid $ \prefix ->
+              forAllValid $ \(key, val) -> do
+                let prefixedKey = prefix <> key
+                let e = EnvMap.insert prefixedKey val e'
+                let p = subEnv prefix $ setting [reader str, env key]
+                let expected = val
+                shouldParse p Args.emptyArgs e mConf expected
 
     describe "subConfig" $ do
       it "can prefix a conf val parser" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \c' ->
-              forAllValid $ \prefix ->
-                forAllValid $ \(key, val) -> do
-                  let c = KeyMap.insert prefix (toJSON (KeyMap.singleton key (toJSON val))) c'
-                  let p =
-                        subConfig (Key.toString prefix) $
-                          setting [conf (Key.toString key)]
-                  let expected = val :: Text
-                  shouldParse p args e (Just c) expected
+        forAllValid $ \e ->
+          forAllValid $ \c' ->
+            forAllValid $ \prefix ->
+              forAllValid $ \(key, val) -> do
+                let c = KeyMap.insert prefix (toJSON (KeyMap.singleton key (toJSON val))) c'
+                let p =
+                      subConfig (Key.toString prefix) $
+                        setting [conf (Key.toString key)]
+                let expected = val :: Text
+                shouldParse p Args.emptyArgs e (Just c) expected
 
     describe "Setting" $ do
       it "can parse a single arg" $
         forAllValid $ \e ->
           forAllValid $ \mConf ->
             forAllValid $ \arg -> do
-              let args = emptyArgs {unArgs = [Live (ArgPlain arg)]}
+              let args = Args.parseArgs [arg]
               let p = setting [reader str, argument]
               let expected = arg
               shouldParse p args e mConf expected
@@ -279,35 +264,32 @@ spec = do
               shouldParse p args e mConf expected
 
       it "can parse a single env var" $
-        forAllValid $ \args ->
-          forAllValid $ \e' ->
-            forAllValid $ \mConf ->
-              forAllValid $ \(key, val) -> do
-                let e = EnvMap.insert key val e'
-                let p = setting [reader str, env key]
-                let expected = val
-                shouldParse p args e mConf expected
+        forAllValid $ \e' ->
+          forAllValid $ \mConf ->
+            forAllValid $ \(key, val) -> do
+              let e = EnvMap.insert key val e'
+              let p = setting [reader str, env key]
+              let expected = val
+              shouldParse p Args.emptyArgs e mConf expected
 
       it "can parse a single config value" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \c' ->
-              forAllValid $ \(key, val) -> do
-                let c = KeyMap.insert key (toJSON val) c'
-                let p = setting [conf (Key.toString key)]
-                let expected = val :: Text
-                shouldParse p args e (Just c) expected
+        forAllValid $ \e ->
+          forAllValid $ \c' ->
+            forAllValid $ \(key, val) -> do
+              let c = KeyMap.insert key (toJSON val) c'
+              let p = setting [conf (Key.toString key)]
+              let expected = val :: Text
+              shouldParse p Args.emptyArgs e (Just c) expected
 
       it "parses Null as the default value" $
-        forAllValid $ \args ->
-          forAllValid $ \e ->
-            forAllValid $ \c' ->
-              forAllValid $ \key -> do
-                let c = KeyMap.insert key JSON.Null c'
-                let defaultVal = "hi"
-                let p = setting [conf (Key.toString key), value defaultVal]
-                let expected = defaultVal
-                shouldParse p args e (Just c) expected
+        forAllValid $ \e ->
+          forAllValid $ \c' ->
+            forAllValid $ \key -> do
+              let c = KeyMap.insert key JSON.Null c'
+              let defaultVal = "hi"
+              let p = setting [conf (Key.toString key), value defaultVal]
+              let expected = defaultVal
+              shouldParse p Args.emptyArgs e (Just c) expected
 
     describe "Unit tests" $ do
       argParseSpec
@@ -527,8 +509,8 @@ spec = do
           (["--watch", "foo"], (True, Just "foo")),
           (["foo"], (False, Just "foo")),
           (["--bar"], (False, Just "--bar")),
-          (["-w"], (False, Nothing)),
-          (["--watch"], (False, Nothing))
+          (["-w"], (True, Nothing)),
+          (["--watch"], (True, Nothing))
         ]
 
       argParseSpecs

--- a/opt-env-conf-test/test_resources/error/typo-option.txt
+++ b/opt-env-conf-test/test_resources/error/typo-option.txt
@@ -1,0 +1,1 @@
+Unrecognised args: --baz arg

--- a/opt-env-conf-test/test_resources/error/typo-switch.txt
+++ b/opt-env-conf-test/test_resources/error/typo-switch.txt
@@ -1,0 +1,1 @@
+Unrecognised args: --baz

--- a/opt-env-conf-test/test_resources/error/unrecognised-arg.txt
+++ b/opt-env-conf-test/test_resources/error/unrecognised-arg.txt
@@ -1,0 +1,1 @@
+Unrecognised args: arg

--- a/opt-env-conf-test/test_resources/error/unrecognised-option.txt
+++ b/opt-env-conf-test/test_resources/error/unrecognised-option.txt
@@ -1,0 +1,1 @@
+Unrecognised args: --foo bar

--- a/opt-env-conf-test/test_resources/error/unrecognised-switch.txt
+++ b/opt-env-conf-test/test_resources/error/unrecognised-switch.txt
@@ -1,0 +1,1 @@
+Unrecognised args: --foo

--- a/opt-env-conf/src/OptEnvConf/Args.hs
+++ b/opt-env-conf/src/OptEnvConf/Args.hs
@@ -109,13 +109,14 @@ instance IsList Args where
 emptyArgs :: Args
 emptyArgs = Args []
 
-argsLeftovers :: Args -> [String]
+argsLeftovers :: Args -> Maybe (NonEmpty String)
 argsLeftovers =
-  mapMaybe
-    ( \case
-        Live a -> Just (renderArg a)
-        Dead -> Nothing
-    )
+  NE.nonEmpty
+    . mapMaybe
+      ( \case
+          Live a -> Just (renderArg a)
+          Dead -> Nothing
+      )
     . unArgs
 
 -- | Create 'Args' with all-live arguments.

--- a/opt-env-conf/src/OptEnvConf/Error.hs
+++ b/opt-env-conf/src/OptEnvConf/Error.hs
@@ -37,6 +37,7 @@ data ParseErrorMessage
   | ParseErrorMissingCommand ![String]
   | ParseErrorUnrecognisedCommand !String ![String]
   | ParseErrorAllOrNothing
+  | ParseErrorUnrecognised
   deriving (Show)
 
 -- | Whether the other side of an 'Alt' should be tried if we find this error.
@@ -61,6 +62,7 @@ errorMessageIsForgivable = \case
   ParseErrorMissingCommand cs -> not $ null cs
   ParseErrorUnrecognisedCommand _ _ -> False
   ParseErrorAllOrNothing -> False
+  ParseErrorUnrecognised -> False
 
 eraseErrorSrcLocs :: (Functor f) => f ParseError -> f ParseError
 eraseErrorSrcLocs = fmap eraseErrorSrcLoc
@@ -125,7 +127,8 @@ renderError ParseError {..} =
           ]
         ParseErrorAllOrNothing ->
           [ ["You are seeing this error because at least one, but not all, of the settings in an allOrNothing (or subSettings) parser have been defined."]
-          ],
+          ]
+        ParseErrorUnrecognised -> [["TODO"]],
       maybe [] (pure . ("see " :) . pure . fore cyan . chunk . T.pack . prettySrcLoc) parseErrorSrcLoc
     ]
 

--- a/opt-env-conf/src/OptEnvConf/Run.hs
+++ b/opt-env-conf/src/OptEnvConf/Run.hs
@@ -272,10 +272,10 @@ runParserOn parser args envVars mConfig = do
           }
   let go' = do
         result <- go parser
-        leftovers <- gets ppStateArgs
-        if null (argsLeftovers leftovers)
-          then pure result
-          else ppError Nothing ParseErrorUnrecognised --
+        leftoverArgs <- gets ppStateArgs
+        case argsLeftovers leftoverArgs of
+          Nothing -> pure result
+          Just leftovers -> ppError Nothing $ ParseErrorUnrecognised leftovers
   mTup <- runPPLazy go' ppState ppEnv
   case mTup of
     Nothing -> error "TODO figure out when this list can be empty"


### PR DESCRIPTION
@L7R7 This changes the way parsing optional arguments work.

I think this change is good, but this test now fails and I'm not sure if it's fixable:

```
argParseSpec                     
        ["--foo", "bar"]
        ((,) <$> setting [reader str, argument] <*> setting [reader str, argument])
        ("--foo", "bar")   
```

```
opt-env-conf-test>     test/OptEnvConf/RunSpec.hs:340
opt-env-conf-test>   ✗ 1 OptEnvConf.RunSpec.runParser.Unit tests.parses ["--foo","bar"] as ("--foo","bar")
opt-env-conf-test>       Retries: 3 (does not look flaky)
opt-env-conf-test>       Expected these values to be equal:
opt-env-conf-test>       Actual:   ( "bar" , "--foo" )
opt-env-conf-test>       Expected: ( "--foo" , "bar" )
```