### PR TITLE
Bump autodocodec-yaml >= 0.3.0.0 to solve #3

### DIFF
--- a/opt-env-conf/package.yaml
+++ b/opt-env-conf/package.yaml
@@ -18,7 +18,7 @@ library:
   - aeson
   - autodocodec >= 0.2.3.0
   - autodocodec-schema
-  - autodocodec-yaml
+  - autodocodec-yaml >= 0.3.0.0
   - containers
   - hashable
   - mtl


### PR DESCRIPTION
* Building with older versions fails: #3 because missing `jsonSchemaChunkLines`.
* Changelog mentioning the addition of the function https://github.com/NorfairKing/autodocodec/blob/master/autodocodec-yaml/CHANGELOG.md#0300---2024-06-23