### PR TITLE
Add quickstart section to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,99 @@
-# OptEnvConf
+# OptEnvConf ![Hackage](https://img.shields.io/hackage/v/opt-env-conf.svg) ![Hackage-Deps](https://img.shields.io/hackage-deps/v/opt-env-conf.svg)
+
+Parse and merge settings for your web app or CLI tool from all typical sources like 
+**configuration files, command-line arguments and environment variables** all with one convenient library.
+
+## Quickstart
+
+<details>
+<summary>
+Click to show the .cabal file part.
+Learn more at <a href="https://cs-syd.eu/posts/2024-07-08-announcing-opt-env-conf" target="_blank">https://cs-syd.eu/posts/2024-07-08-announcing-opt-env-conf</a>
+</summary>
+
+```cabal
+executable myApp
+  build-depends:
+    ...
+    , opt-env-conf
+```
+
+</details>
+<p></p>
+
+```haskell
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Main where
+
+import Data.Text (Text)
+import OptEnvConf
+import Data.Version (Version, makeVersion)
+
+########################## Usage
+
+appVersion :: Version
+appVersion = makeVersion [1, 0, 0]
+
+main :: IO ()
+main = do
+  settings <- runSettingsParser appVersion "Run the foo-bar server"
+  runServer settings
+
+runServer :: Settings -> IO ()
+runServer = do
+  putStrLn "Parsing worked!"
+
+########################## Settings definitions
+
+data Settings = Settings
+  { settingPort :: Int,
+    settingPaymentSettings :: Maybe PaymentSettings
+  }
+
+data PaymentSettings = PaymentSettings
+  { paymentSettingPublicKey :: Text,
+    paymentSettingPrivateKey :: Text
+  }
+
+########################## Parsing configuration
+
+instance HasParser Settings where
+  settingsParser = subEnv "FOO_BAR_" $ withLocalYamlConfig $ do
+    settingPort <-
+      setting
+        [ help "the port to serve web requests on",
+          reader auto,
+          option,
+          long "port",
+          env "PORT",
+          conf "port",
+          metavar "PORT",
+          value 8080
+        ]
+    settingPaymentSettings <- optional $ subSettings "payment"
+    pure Settings {..}
+
+instance HasParser PaymentSettings where
+  settingsParser = do
+    paymentSettingPublicKey <-
+      setting
+        [ help "public key",
+          reader str,
+          name "public-key",
+          metavar "PUBLIC_KEY"
+        ]
+    paymentSettingPrivateKey <-
+      mapIO readSecretTextFile $
+        filePathSetting
+          [ help "private key file",
+            reader str,
+            name "private-key-file",
+            metavar "PRIVATE_KEY_FILE"
+          ]
+    pure PaymentSettings {..}
+```
 
 ## Status
 


### PR DESCRIPTION
The existing Readme is missing your example how to get up and running, and get a feel for the library quickly. It would be great if this Readme could also be used as the landing page at https://hackage.haskell.org/package/opt-env-conf-0.5.0.1

@NorfairKing Many thanks for this awesome library.
Feel free to modify, request changes or remove this PR.