### PR TITLE
Don't show a String in renderErrors

### DIFF
--- a/opt-env-conf/src/OptEnvConf/Error.hs
+++ b/opt-env-conf/src/OptEnvConf/Error.hs
@@ -113,7 +113,7 @@ renderError ParseError {..} =
         ParseErrorConfigRead md s ->
           ["Failed to parse configuration: "]
             : maybe [] renderConfDoc md
-            ++ [[chunk $ T.pack $ show s]]
+            ++ [[chunk $ T.pack s]]
         ParseErrorMissingCommand cs ->
           ["Missing command, available commands:"]
             : availableCommandsLines cs


### PR DESCRIPTION
This causes parsing errors to come out quote-escaped instead of printed
normally.
