### PR TITLE
Change `withShownDefault` and `valueWithShown` to accept a function

### DIFF
--- a/opt-env-conf-test/test/OptEnvConf/APISpec.hs
+++ b/opt-env-conf-test/test/OptEnvConf/APISpec.hs
@@ -188,7 +188,7 @@ sumTypeParser =
               ],
             setting
               [ h,
-                valueWithShown SumTypeA "a"
+                valueWithShown renderSumType SumTypeA
               ]
           ]
 

--- a/opt-env-conf/CHANGELOG.md
+++ b/opt-env-conf/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.8.0.0] - 2024-11-05
+
+* Change `withShownDefault` and `valueWithShown` to accept a function to use in
+  place of `show` rather than a pre-rendered `String`.
+
 ## [0.7.0.1] - 2024-10-27
 
 ### Changed

--- a/opt-env-conf/opt-env-conf.cabal
+++ b/opt-env-conf/opt-env-conf.cabal
@@ -1,11 +1,11 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           opt-env-conf
-version:        0.7.0.1
+version:        0.8.0.0
 synopsis:       Settings parsing for Haskell: command-line arguments, environment variables, and configuration values.
 homepage:       https://github.com/NorfairKing/opt-env-conf#readme
 bug-reports:    https://github.com/NorfairKing/opt-env-conf/issues

--- a/opt-env-conf/package.yaml
+++ b/opt-env-conf/package.yaml
@@ -1,5 +1,5 @@
 name: opt-env-conf
-version: '0.7.0.1'
+version: '0.8.0.0'
 github: "NorfairKing/opt-env-conf"
 copyright: ! 'Copyright: (c) 2024 Tom Sydney Kerckhove'
 license: LGPL-3
@@ -7,7 +7,7 @@ license-file: LICENSE
 synopsis: 'Settings parsing for Haskell: command-line arguments, environment variables, and configuration values.'
 author: "Tom Sydney Kerckhove"
 maintainer: "syd@cs-syd.eu"
- 
+
 extra-source-files:
 - CHANGELOG.md
 

--- a/opt-env-conf/src/OptEnvConf/Parser.hs
+++ b/opt-env-conf/src/OptEnvConf/Parser.hs
@@ -515,12 +515,12 @@ someNonEmpty = ParserSome
 --
 -- This does nothing if the parser already has a default value.
 withDefault :: (Show a) => a -> Parser a -> Parser a
-withDefault defaultValue = withShownDefault defaultValue (show defaultValue)
+withDefault = withShownDefault show
 
 -- | Like 'withDefault' but lets you specfiy how to show the default value
 -- yourself.
-withShownDefault :: a -> String -> Parser a -> Parser a
-withShownDefault defaultValue shownDefault = go
+withShownDefault :: (a -> String) -> a -> Parser a -> Parser a
+withShownDefault showDefault defaultValue = go
   where
     go p =
       let p' = p <|> pure defaultValue
@@ -537,7 +537,7 @@ withShownDefault defaultValue shownDefault = go
             ParserCommands {} -> p'
             ParserWithConfig {} -> p'
             ParserSetting mLoc s -> case settingDefaultValue s of
-              Nothing -> ParserSetting mLoc $ s {settingDefaultValue = Just (defaultValue, shownDefault)}
+              Nothing -> ParserSetting mLoc $ s {settingDefaultValue = Just (defaultValue, showDefault defaultValue)}
               Just _ -> p
 
 -- | Try a list of parsers in order

--- a/opt-env-conf/src/OptEnvConf/Setting.hs
+++ b/opt-env-conf/src/OptEnvConf/Setting.hs
@@ -349,11 +349,11 @@ name s =
 -- API Note: @default@ is not a valid identifier in Haskell.
 -- I'd also have preferred @default@ instead.
 value :: (Show a) => a -> Builder a
-value a = valueWithShown a (show a)
+value = valueWithShown show
 
--- | Set the default value, along with a shown version of it.
-valueWithShown :: a -> String -> Builder a
-valueWithShown a shown = Builder [BuildSetDefault a shown]
+-- | Set the default value, along with version of it shown by a custom function.
+valueWithShown :: (a -> String) -> a -> Builder a
+valueWithShown show' a = Builder [BuildSetDefault a (show' a)]
 
 -- | Provide an example value for documentation.
 --

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,7 @@ extra-deps:
     - autodocodec-schema
     - autodocodec-nix
 
-# system-ghc: true
-# nix:
-#   enable: false
-# with-hpack: hpack
+system-ghc: true
+nix:
+  enable: false
+with-hpack: hpack

--- a/stack.yaml
+++ b/stack.yaml
@@ -22,7 +22,7 @@ extra-deps:
     - autodocodec-schema
     - autodocodec-nix
 
-system-ghc: true
-nix:
-  enable: false
-with-hpack: hpack
+# system-ghc: true
+# nix:
+#   enable: false
+# with-hpack: hpack


### PR DESCRIPTION
### [Change withShownDefault to accept a function](https://github.com/NorfairKing/opt-env-conf/pull/17/commits/1f3567bf35a4989186a3bb35669afebabe4fb927)
[1f3567b](https://github.com/NorfairKing/opt-env-conf/pull/17/commits/1f3567bf35a4989186a3bb35669afebabe4fb927)

It's common to use this function on a type with a custom "show-like"
function. Under such usage, the ergonomics are not ideal:

```hs
withShownDefault defaultFoo (showFoo defaultFoo)
```

This function is more ergonomic:

```hs
withShownDefault showFoo defaultFoo
```

As an example, the simplified `withDefault = withShownDefault show`
reads very clearly. The previous behavior can also be recovered easily
with `const`.

### [Update valueWithShown to accept a function](https://github.com/NorfairKing/opt-env-conf/pull/17/commits/5bbbebd650b1c77f1b8f15784c9501463f3d5df0)
[5bbbebd](https://github.com/NorfairKing/opt-env-conf/pull/17/commits/5bbbebd650b1c77f1b8f15784c9501463f3d5df0)

The arguments for this are the same as the previous change to
`withShownDefault`.

### [Version bump and CHANGELOG](https://github.com/NorfairKing/opt-env-conf/pull/17/commits/4f135bf3e639c03debc02c01976ca1389c5372d8)