### PR TITLE
Windows support and gitignore cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 stack.yaml.lock
 .stack-work/
+.direnv
+.pre-commit-config.yaml
+result

--- a/opt-env-conf/CHANGELOG.md
+++ b/opt-env-conf/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+
+## [0.11.1.0] - 2025-10-23
+
+### Added
+
+* Windows support by isolating platform-specific terminal code.
+
 ## [0.11.0.0] - 2025-09-29
 
 This is technically a breaking change, but if you don't use any `opt-env-conf`

--- a/opt-env-conf/default.nix
+++ b/opt-env-conf/default.nix
@@ -6,7 +6,7 @@
 }:
 mkDerivation {
   pname = "opt-env-conf";
-  version = "0.11.0.0";
+  version = "0.11.1.0";
   src = ./.;
   libraryHaskellDepends = [
     aeson autodocodec autodocodec-nix autodocodec-schema

--- a/opt-env-conf/opt-env-conf.cabal
+++ b/opt-env-conf/opt-env-conf.cabal
@@ -40,6 +40,7 @@ library
       OptEnvConf.Reader
       OptEnvConf.Run
       OptEnvConf.Setting
+      OptEnvConf.Terminal
       OptEnvConf.Validation
   other-modules:
       Paths_opt_env_conf
@@ -60,9 +61,11 @@ library
     , path-io
     , safe-coloured-text >=0.3.0.2
     , safe-coloured-text-layout >=0.2.0.0
-    , safe-coloured-text-terminfo
     , selective
     , text
     , validity
     , validity-containers
   default-language: Haskell2010
+  if !os(windows)
+    build-depends:
+        safe-coloured-text-terminfo

--- a/opt-env-conf/opt-env-conf.cabal
+++ b/opt-env-conf/opt-env-conf.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           opt-env-conf
-version:        0.11.0.0
+version:        0.11.1.0
 synopsis:       Settings parsing for Haskell: command-line arguments, environment variables, and configuration values.
 homepage:       https://github.com/NorfairKing/opt-env-conf#readme
 bug-reports:    https://github.com/NorfairKing/opt-env-conf/issues

--- a/opt-env-conf/package.yaml
+++ b/opt-env-conf/package.yaml
@@ -31,8 +31,11 @@ library:
   - path-io
   - safe-coloured-text >= 0.3.0.2
   - safe-coloured-text-layout >= 0.2.0.0
-  - safe-coloured-text-terminfo # TODO Don't depend on this on windows
   - selective
   - text
   - validity
   - validity-containers
+  when:
+    - condition: "!os(windows)"
+      dependencies:
+        - safe-coloured-text-terminfo

--- a/opt-env-conf/package.yaml
+++ b/opt-env-conf/package.yaml
@@ -1,5 +1,5 @@
 name: opt-env-conf
-version: '0.11.0.0'
+version: '0.11.1.0'
 github: "NorfairKing/opt-env-conf"
 copyright: ! 'Copyright: (c) 2024-2025 Tom Sydney Kerckhove'
 license: LGPL-3

--- a/opt-env-conf/src/OptEnvConf/Completer.hs
+++ b/opt-env-conf/src/OptEnvConf/Completer.hs
@@ -14,7 +14,6 @@ import Data.List
 import Data.Maybe
 import Path
 import Path.IO
-import Path.Internal.Posix (Path (..))
 
 newtype Completer = Completer {unCompleter :: String -> IO [String]}
 
@@ -149,7 +148,7 @@ directoryPath = Completer $ \fp' -> do
         ]
 
 hiddenRel :: Path Rel f -> Bool
-hiddenRel (Path s) = case s of
+hiddenRel p = case toFilePath p of
   ('.' : _) -> True
   _ -> False
 

--- a/opt-env-conf/src/OptEnvConf/Run.hs
+++ b/opt-env-conf/src/OptEnvConf/Run.hs
@@ -46,13 +46,13 @@ import OptEnvConf.Output
 import OptEnvConf.Parser
 import OptEnvConf.Reader
 import OptEnvConf.Setting
+import OptEnvConf.Terminal (getTerminalCapabilitiesFromHandle)
 import OptEnvConf.Validation
 import Path
 import System.Environment (getArgs, getEnvironment, getProgName)
 import System.Exit
 import System.IO
 import Text.Colour
-import Text.Colour.Capabilities.FromEnv
 
 -- | Run 'runParser' on your @Settings@' type's 'settingsParser'.
 --

--- a/opt-env-conf/src/OptEnvConf/Terminal.hs
+++ b/opt-env-conf/src/OptEnvConf/Terminal.hs
@@ -1,0 +1,20 @@
+{-# LANGUAGE CPP #-}
+
+module OptEnvConf.Terminal
+  ( getTerminalCapabilitiesFromHandle,
+  )
+where
+
+#if !defined(mingw32_HOST_OS)
+import Text.Colour.Capabilities.FromEnv (getTerminalCapabilitiesFromHandle)
+#else
+import System.IO (Handle, hIsTerminalDevice)
+import Text.Colour.Capabilities (TerminalCapabilities (..))
+
+getTerminalCapabilitiesFromHandle :: Handle -> IO TerminalCapabilities
+getTerminalCapabilitiesFromHandle h = do
+  isTerm <- hIsTerminalDevice h
+  pure $ if isTerm then With8BitColours else WithoutColours
+  -- Note: This may be conservative. Modern Windows terminals (Windows 10+)
+  -- support 24-bit RGB colors when VT processing is enabled.
+#endif


### PR DESCRIPTION
Hey! Great lib :)

I am building a cli tool with opt-env-conf and I'd like to make available for Windows too, here are is my proposal, consisting in:

• Isolating platform-specific terminal code into a dedicated module
• Clean up gitignore to exclude direnv and nix-generated files
